### PR TITLE
✨ (slice): Introduce `SliceExt` trait with `has_dup` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### Added
+
+- (slice): Introduce `SliceExt` trait with `has_dup` method ([](https://github.com/opensound-org/est/commit/))
+
 ### Docs
 
 - (README): Update `git-msrv` badge ([](https://github.com/opensound-org/est/commit/))

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ full = [
   "future",
   "process",
   "result",
+  "slice",
   "sync",
   "task",
   "thread",
@@ -64,6 +65,7 @@ collections = ["dep:thiserror"]
 future = []
 process = ["tokio/process"]
 result = ["dep:anyhow"]
+slice = []
 sync = ["tokio/sync"]
 task = ["future", "sync", "dep:derive_more", "tokio/rt"]
 thread = ["dep:derive_more", "dep:ron"]

--- a/README-CN.md
+++ b/README-CN.md
@@ -36,6 +36,7 @@
 - [`future::FutureExt::with_cancel_signal()`](https://docs.rs/est/latest/est/future/trait.FutureExt.html#tymethod.with_cancel_signal)
 - [`future::IntoFutureWithArgs`](https://docs.rs/est/latest/est/future/trait.IntoFutureWithArgs.html)
 - [`process::Command`](https://docs.rs/est/latest/est/process/enum.Command.html)
+- [`slice::SliceExt::has_dup()`](https://docs.rs/est/latest/est/slice/trait.SliceExt.html#tymethod.has_dup)
 - [`sync::once`](https://docs.rs/est/latest/est/sync/once/index.html)
 - [`task::task_tracker::CloseAndWait::close_and_wait()`](https://docs.rs/est/latest/est/task/task_tracker/trait.CloseAndWait.html#tymethod.close_and_wait)
 - [`task::GracefulTask`](https://docs.rs/est/latest/est/task/graceful/struct.GracefulTask.html)

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Some of the items are as follows:
 - [`future::FutureExt::with_cancel_signal()`](https://docs.rs/est/latest/est/future/trait.FutureExt.html#tymethod.with_cancel_signal)
 - [`future::IntoFutureWithArgs`](https://docs.rs/est/latest/est/future/trait.IntoFutureWithArgs.html)
 - [`process::Command`](https://docs.rs/est/latest/est/process/enum.Command.html)
+- [`slice::SliceExt::has_dup()`](https://docs.rs/est/latest/est/slice/trait.SliceExt.html#tymethod.has_dup)
 - [`sync::once`](https://docs.rs/est/latest/est/sync/once/index.html)
 - [`task::task_tracker::CloseAndWait::close_and_wait()`](https://docs.rs/est/latest/est/task/task_tracker/trait.CloseAndWait.html#tymethod.close_and_wait)
 - [`task::GracefulTask`](https://docs.rs/est/latest/est/task/graceful/struct.GracefulTask.html)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@ pub mod process;
 /// Extensions to the [`std::result`] module.
 #[cfg(feature = "result")]
 pub mod result;
-/// Extensions to the [`slice`] type.
+/// Extensions to the [`std::slice`] module.
 #[cfg(feature = "slice")]
 pub mod slice;
 /// Extensions to the [`std::sync`] & [`tokio::sync`] module.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@
 //!
 //! **The default feature will not enable anything** (based on the principle of minimum
 //! dependency). At the same time, each top-level module has a feature flag with the same name
-//! (currently including: `collections`, `future`, `process`, `result`, `sync`, `task`, `thread`).
+//! (currently including: `collections`, `future`, `process`, `result`, `slice`, `sync`, `task`, `thread`).
 //!
 //! There is also a feature flag called `full` that enables all features and introduces all
 //! optional dependencies.
@@ -34,6 +34,9 @@ pub mod process;
 /// Extensions to the [`std::result`] module.
 #[cfg(feature = "result")]
 pub mod result;
+/// Extensions to the [`slice`] type.
+#[cfg(feature = "slice")]
+pub mod slice;
 /// Extensions to the [`std::sync`] & [`tokio::sync`] module.
 #[cfg(feature = "sync")]
 pub mod sync;

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -1,0 +1,170 @@
+use std::collections::HashSet;
+use std::hash::Hash;
+
+/// Extensions to the [`slice`] type.
+pub trait SliceExt<T> {
+    /// Check if the slice contains duplicate elements.
+    ///
+    /// This method returns `true` if there are any duplicate elements in the slice,
+    /// and `false` if all elements are unique.
+    ///
+    /// # Time Complexity
+    ///
+    /// This method has O(n) average time complexity, where n is the length of the slice.
+    /// In the worst case (with many hash collisions), it could degrade to O(n²), but
+    /// this is extremely rare with a good hash function.
+    ///
+    /// # Space Complexity
+    ///
+    /// This method uses O(n) additional space to store the seen elements.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use est::slice::SliceExt;
+    ///
+    /// let slice_with_dups = [1, 2, 3, 2, 4];
+    /// assert!(slice_with_dups.has_dup());
+    ///
+    /// let slice_without_dups = [1, 2, 3, 4, 5];
+    /// assert!(!slice_without_dups.has_dup());
+    ///
+    /// let empty_slice: [i32; 0] = [];
+    /// assert!(!empty_slice.has_dup());
+    ///
+    /// let single_element = [42];
+    /// assert!(!single_element.has_dup());
+    /// ```
+    ///
+    /// # Type Requirements
+    ///
+    /// The element type `T` must implement [`Hash`] and [`Eq`] traits to be used
+    /// in the internal [`HashSet`].
+    fn has_dup(&self) -> bool
+    where
+        T: Hash + Eq;
+}
+
+impl<T> SliceExt<T> for [T] {
+    fn has_dup(&self) -> bool
+    where
+        T: Hash + Eq,
+    {
+        let mut seen = HashSet::with_capacity(self.len());
+
+        for item in self {
+            if !seen.insert(item) {
+                return true;
+            }
+        }
+
+        false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_has_dup_with_duplicates() {
+        let slice = [1, 2, 3, 2, 4];
+        assert!(slice.has_dup());
+    }
+
+    #[test]
+    fn test_has_dup_without_duplicates() {
+        let slice = [1, 2, 3, 4, 5];
+        assert!(!slice.has_dup());
+    }
+
+    #[test]
+    fn test_has_dup_empty_slice() {
+        let slice: [i32; 0] = [];
+        assert!(!slice.has_dup());
+    }
+
+    #[test]
+    fn test_has_dup_single_element() {
+        let slice = [42];
+        assert!(!slice.has_dup());
+    }
+
+    #[test]
+    fn test_has_dup_all_same_elements() {
+        let slice = [5, 5, 5, 5];
+        assert!(slice.has_dup());
+    }
+
+    #[test]
+    fn test_has_dup_two_elements_same() {
+        let slice = [1, 1];
+        assert!(slice.has_dup());
+    }
+
+    #[test]
+    fn test_has_dup_two_elements_different() {
+        let slice = [1, 2];
+        assert!(!slice.has_dup());
+    }
+
+    #[test]
+    fn test_has_dup_strings() {
+        let slice = ["hello", "world", "hello"];
+        assert!(slice.has_dup());
+
+        let slice_no_dup = ["hello", "world", "rust"];
+        assert!(!slice_no_dup.has_dup());
+    }
+
+    #[test]
+    fn test_has_dup_large_slice() {
+        // Test with a larger slice to ensure performance
+        let mut vec = Vec::new();
+        for i in 0..1000 {
+            vec.push(i);
+        }
+        assert!(!vec.has_dup());
+
+        // Add a duplicate
+        vec.push(500);
+        assert!(vec.has_dup());
+    }
+
+    #[test]
+    fn test_has_dup_duplicate_at_end() {
+        let slice = [1, 2, 3, 4, 5, 1];
+        assert!(slice.has_dup());
+    }
+
+    #[test]
+    fn test_has_dup_duplicate_at_beginning() {
+        let slice = [1, 1, 2, 3, 4, 5];
+        assert!(slice.has_dup());
+    }
+
+    #[test]
+    fn test_has_dup_with_vec() {
+        let vec = vec![1, 2, 3, 2, 4];
+        assert!(vec.has_dup());
+
+        let vec_no_dup = vec![1, 2, 3, 4, 5];
+        assert!(!vec_no_dup.has_dup());
+    }
+
+    #[test]
+    fn test_has_dup_with_slice_reference() {
+        let array = [1, 2, 3, 2, 4];
+        let slice = &array[..];
+        assert!(slice.has_dup());
+    }
+
+    #[test]
+    fn test_has_dup_chars() {
+        let chars = ['a', 'b', 'c', 'a'];
+        assert!(chars.has_dup());
+
+        let chars_no_dup = ['a', 'b', 'c', 'd'];
+        assert!(!chars_no_dup.has_dup());
+    }
+}


### PR DESCRIPTION
This PR implements a new `SliceExt` trait with a `has_dup` method as requested in issue #28.

## Changes

- **New slice module**: Added `src/slice.rs` with the `SliceExt` trait
- **has_dup method**: Efficiently checks for duplicate elements in O(n) average time complexity
- **Feature flag**: Added `slice` feature to `Cargo.toml` following project conventions
- **Comprehensive tests**: 14 unit tests covering various scenarios including edge cases
- **Documentation**: Detailed rustdoc with examples and complexity analysis

## Implementation Details

The `has_dup` method uses a `HashSet` to track seen elements, providing:
- **Time Complexity**: O(n) average case, O(n²) worst case (rare with good hash function)
- **Space Complexity**: O(n) for storing seen elements
- **Generic Support**: Works with any type implementing `Hash + Eq`

## Test Coverage

The implementation includes comprehensive tests for:
- ✅ Slices with duplicates
- ✅ Slices without duplicates  
- ✅ Empty slices
- ✅ Single element slices
- ✅ All same elements
- ✅ Different data types (integers, strings, chars)
- ✅ Vec and slice references
- ✅ Large slices (performance verification)
- ✅ Edge cases (duplicates at beginning/end)

## Usage Example

```rust
use est::slice::SliceExt;

let slice_with_dups = [1, 2, 3, 2, 4];
assert!(slice_with_dups.has_dup());

let slice_without_dups = [1, 2, 3, 4, 5];
assert!(!slice_without_dups.has_dup());
```

Fixes #28

@czy-29 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/c474a7342df544d9998c9fc3d6a4cdba)